### PR TITLE
Fixes video playback issue

### DIFF
--- a/client/controllers/moveDetailsController.js
+++ b/client/controllers/moveDetailsController.js
@@ -29,7 +29,7 @@ stripeTime.controller('moveDetailsCtrl', function($scope, $stateParams, $meteor,
     $scope.firstFlashCard = true;
     $scope.video = $document.find('.move_video');
 
-    $scope.video.on('loadeddata', function(event) {
+    $scope.video.one('canplay', function(event){
       // wait til the video is loaded
       showQuestion();
     });
@@ -40,6 +40,7 @@ stripeTime.controller('moveDetailsCtrl', function($scope, $stateParams, $meteor,
   }
 
   function showQuestion() {
+
     hideAnswerOverlay();
     var flashCard = currentFlashCard();
 


### PR DESCRIPTION
Changes event from `loadeddata` to `canplay`, to wait for the video to have enough data to play a few seconds before triggering $timeout.

This creates another issue, where the video first-frame is loaded but there is a long delay until the user receives UI feedback.

Possible solution would be to add a visual loading state, that is then deactivated when the $timeout is triggered.

@evjan: Another issue is that video jank appears to *also* be caused by video start/end timing discrepencies on the video model itself. This could potentially be fixed by db validation on flashcard entry, or mitigated by video fade-in/out.